### PR TITLE
Consistency fixes for wrap-authenticate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Change Log
 All notable changes to this project will be documented in this file. This change log follows the conventions of [keepachangelog.com](http://keepachangelog.com/).
 
+## [Unreleased]
+### Fixed
+- `wrap-authenticate` now accepts the same values for `public-key` as `authentic?`
+
 ## [1.0.0]
 ### Added
 - Unit tests

--- a/src/ring_discord_auth/ring.clj
+++ b/src/ring_discord_auth/ring.clj
@@ -26,7 +26,7 @@
 
   This middleware supports both synchronous and asynchronous handlers."
   [handler public-key]
-  (let [public-key (core/public-key->signer-verifier)]
+  (let [public-key (core/public-key->signer-verifier public-key)]
     (fn
       ([request respond raise]
        (let [validator (wrap-authenticate identity public-key)


### PR DESCRIPTION
Prior to the changes of this PR, `wrap-authenticate` only accepted strings or byte arrays as the public key argument. It now uses the same coercion function as the rest of the library, making the middleware more consistent.